### PR TITLE
Add ISC-Bench: Internal Safety Collapse in Frontier LLMs

### DIFF
--- a/subtopic/Datasets&Benchmark.md
+++ b/subtopic/Datasets&Benchmark.md
@@ -404,6 +404,7 @@
 | 26.03 | Institute of Science Tokyo | arxiv | [JUBAKU: An Adversarial Benchmark for Exposing Culturally Grounded Stereotypes in Japanese LLMs](https://arxiv.org/abs/2603.20581) | **Social bias**&**Japanese LLMs**&**Cultural stereotypes** |
 | 26.03 | Department of Electrical, Computer and Biomedical Engineering, University of Pavia, Italy | arxiv | [SecureBreak - A dataset towards safe and secure models](https://arxiv.org/abs/2603.21975) | **Safety dataset**&**Unsafe outputs**&**Security alignment** |
 | 26.03 | CSIRO Data61, Australia | arxiv | [Does Teaming-Up LLMs Improve Secure Code Generation? A Comprehensive Evaluation with Multi-LLMSecCodeEval](https://arxiv.org/abs/2603.22717) | **Secure code generation**&**Multi-LLM ensembles**&**Static analysis** |
+| 26.03 | Deakin University, Australia | arxiv | [Internal Safety Collapse in Frontier Large Language Models](https://arxiv.org/abs/2603.23509) | **Jailbreak Benchmark**&**Task-Driven Attack**&**Cross-Domain Safety Failure** |
 
 
 

--- a/subtopic/Jailbreaks&Attack.md
+++ b/subtopic/Jailbreaks&Attack.md
@@ -1009,6 +1009,7 @@
 | 26.03 | The Chinese University of Hong Kong, Shenzhen | arxiv | [PIDP-Attack: Combining Prompt Injection with Database Poisoning Attacks on Retrieval-Augmented Generation Systems](https://arxiv.org/abs/2603.25164) | **RAG poisoning**&**Prompt injection**&**Compound attacks** |
 | 26.03 | Ben-Gurion University of the Negev, Israel | arxiv | [Shape and Substance: Dual-Layer Side-Channel Attacks on Local Vision-Language Models](https://arxiv.org/abs/2603.25403) | **Side-channel attacks**&**Vision-language models**&**Edge privacy** |
 | 26.03 | Algoverse AI Research | EACL SRW 2026 | [When Prompt Optimization Becomes Jailbreaking: Adaptive Red-Teaming of Large Language Models](https://arxiv.org/abs/2603.19247) | **Adaptive red-teaming**&**Prompt optimization**&**Jailbreaking** |
+| 26.03 | Deakin University, Australia | arxiv | [Internal Safety Collapse in Frontier Large Language Models](https://arxiv.org/abs/2603.23509) | **Task-driven jailbreak**&**Cross-domain safety failure**&**Agentic attack** |
 
 
 


### PR DESCRIPTION
**ISC-Bench**: A novel safety failure mode — not a prompt attack, but a structural vulnerability where task completion overrides safety alignment. Black-box, cross-domain, cross-science.

**Jailbreaks any frontier LLM in pass@3** — including Claude Opus 4.6, GPT-5.4, Gemini 3.1 Pro, and Grok 4.20. No adversarial prompting needed.

Key highlights:
- New failure mode: models enter a jailbroken state through normal task completion, not adversarial inputs
- Black-box: works without model internals, API access only
- Cross-domain: 8+ professional disciplines (AI/ML, biology, chemistry, cybersecurity, epidemiology, pharmacology, genomics, media)
- Three attack modes: single-turn, in-context learning, and agentic execution

Paper: [arXiv:2603.23509](https://arxiv.org/abs/2603.23509)
Code: [github.com/wuyoscar/ISC-Bench](https://github.com/wuyoscar/ISC-Bench)