### PR TITLE
Add APort to LLM defense resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ I can offer you a promotional spot here for up to one month.
 | Date  |    Type    |         Title         |                              URL                              |
 |:-----:|:----------:|:---------------------:|:-------------------------------------------------------------:|
 | 23.10 | Tutorials  |  Awesome-LLM-Safety   |     [link](https://github.com/ydyjya/Awesome-LLM-Safety)      |
+| 26.05 | Repository | APort Agent Guardrails | [website](https://aport.io)<br/>[examples](https://github.com/aporthq/aport-integrations) |
 
 ### Other
 

--- a/subtopic/Defense&Mitigation.md
+++ b/subtopic/Defense&Mitigation.md
@@ -878,6 +878,7 @@
 | Date  |   Type    |       Title        |                         URL                          |
 |:-----:|:---------:|:------------------:|:----------------------------------------------------:|
 | 23.10 | Tutorials | Awesome-LLM-Safety | [link](https://github.com/ydyjya/Awesome-LLM-Safety) |
+| 26.05 | Repository | APort Agent Guardrails | [website](https://aport.io)<br/>[examples](https://github.com/aporthq/aport-integrations) |
 
 ## 📰News & Articles
 


### PR DESCRIPTION
Adds APort Agent Guardrails to the Defenses & Mitigation resources.

- Adds the entry to the main README defense resources
- Adds the matching entry to `subtopic/Defense&Mitigation.md`
- Links both the APort website and guardrail integration examples

Validation:
- Verified https://aport.io returns HTTP 200
- Verified https://github.com/aporthq/aport-integrations returns HTTP 200
- Ran `git diff --check`