### PR TITLE
Add PACT: a compliance benchmark for enterprise AI assistants under pressure

### DIFF
--- a/subtopic/Datasets&Benchmark.md
+++ b/subtopic/Datasets&Benchmark.md
@@ -530,6 +530,7 @@
 | 26.07 | dreadnode, USA | arxiv | [ScopeJudge: Cost-Aware Pre-Execution Gating for Offensive Security Agents](https://arxiv.org/abs/2607.07774) | **agent safety**&**scope enforcement**&**LLM monitoring** |
 | 26.07 | LASR Labs | arxiv | [Persuasion Attacks Can Decrease Effectiveness of CoT Monitoring](https://arxiv.org/abs/2607.08066) | **CoT monitoring**&**persuasion attacks**&**AI oversight** |
 
+| 26.08 | TRACE AI Labs | preprint | [PACT: Can Enterprise AI Assistants Be Trusted Under Pressure?](https://www.alphaxiv.org/pdf/2609.pact-enterprise-ai-compliance-testing) | **Compliance Benchmark**&**Enterprise AI Assistants**&**Pressure Testing** |
 
 
 ## 📚Resource


### PR DESCRIPTION
Adds one row to `subtopic/Datasets&Benchmark.md`.

**PACT: Can Enterprise AI Assistants Be Trusted Under Pressure?** (preprint, 2026) is a compliance benchmark of 3,364 multi-turn items across 12 regulated domains. It tests whether enterprise AI assistants keep following company rules when a deadline, a manager, or a pushy user makes breaking them convenient.

- Paper: https://www.alphaxiv.org/pdf/2609.pact-enterprise-ai-compliance-testing
- Site (leaderboard, results, trial transcripts): https://trace-ai-labs.github.io/pact/
- Dataset: https://huggingface.co/datasets/trace-ai-labs/pact
- Code: https://github.com/trace-ai-labs/pact